### PR TITLE
Set up CI/CD pipeline with GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,66 @@
+name: Docs
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    
+    - name: Install uv
+      run: |
+        pip install uv
+    
+    - name: Install dependencies
+      run: |
+        uv pip install -e ".[docs]"
+    
+    - name: Build docs
+      run: |
+        python -m mkdocs build --strict
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    
+    - name: Install uv
+      run: |
+        pip install uv
+    
+    - name: Install dependencies
+      run: |
+        uv pip install -e ".[docs]"
+    
+    - name: Deploy docs
+      run: |
+        python -m mkdocs gh-deploy --force

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    
+    - name: Install build dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+    
+    - name: Build and check package
+      run: |
+        python -m build
+        twine check dist/*
+    
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        skip_existing: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    
+    - name: Install uv
+      run: |
+        pip install uv
+    
+    - name: Install dependencies
+      run: |
+        uv pip install -e ".[test,lint]"
+    
+    - name: Lint with ruff
+      run: |
+        ruff check rag_evals tests
+    
+    - name: Type check with mypy
+      run: |
+        mypy rag_evals
+    
+    # We run tests with mocks since GitHub Actions won't have OpenAI API keys
+    - name: Test with pytest (mocked)
+      run: |
+        pytest tests/ -v


### PR DESCRIPTION
## Summary
- Add test workflow for linting, type checking, and running tests
- Add docs workflow for building and deploying documentation
- Add publish workflow for PyPI releases

## Test plan
- Verify that GitHub Actions workflows run correctly on pull requests
- Ensure documentation builds and deploys appropriately
- Confirm that PyPI publishing workflow is triggered on releases

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set up GitHub Actions workflows for testing, documentation deployment, and PyPI publishing.
> 
>   - **Workflows**:
>     - Adds `test.yml` for linting, type checking, and running tests on Python versions 3.8 to 3.11.
>     - Adds `docs.yml` to build and deploy documentation using MkDocs on changes to `docs/**`, `mkdocs.yml`, or the workflow file itself.
>     - Adds `publish.yml` to publish package to PyPI on release creation.
>   - **Testing**:
>     - Uses `ruff` for linting and `mypy` for type checking in `test.yml`.
>     - Runs `pytest` with mocks due to lack of OpenAI API keys.
>   - **Documentation**:
>     - Builds docs with `mkdocs build --strict` and deploys with `mkdocs gh-deploy --force` in `docs.yml`.
>   - **Publishing**:
>     - Builds package with `python -m build` and checks with `twine` in `publish.yml`.
>     - Publishes to PyPI using `pypa/gh-action-pypi-publish`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jxnl%2Fragas-alt&utm_source=github&utm_medium=referral)<sup> for 1e06a8f4803b6180487c00d2832a22b1e404e287. You can [customize](https://app.ellipsis.dev/jxnl/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->